### PR TITLE
using non-jsx in renders

### DIFF
--- a/src/grid.js
+++ b/src/grid.js
@@ -214,14 +214,19 @@ var InfiniteGrid = React.createClass({
                 }
             }
         }
+	
+		var grid = React.createElement("div",{
+			ref: "grid",
+			className: "infinite-grid",
+			style: this._gridStyle()
+		});
 
-        return(
-            <div ref="wrapper" className="infinite-grid-wrapper" onScroll={this._scrollListener} style={this._wrapperStyle()}>
-                <div ref="grid" className="infinite-grid" style={this._gridStyle()}>
-                    {entries}
-                </div>
-            </div>
-        );
+		return React.createElement("div",{
+			ref:"wrapper",
+			className:"infinite-grid-wrapper",
+			onScroll: this._scrollListener,
+			style: this._wrapperStyle()
+		},grid);
     },
 });
 

--- a/src/grid.js
+++ b/src/grid.js
@@ -4,217 +4,218 @@ var Item = require('./item');
 
 var InfiniteGrid = React.createClass({
 
-    mixins: [ PureRenderMixin ],
+		mixins: [ PureRenderMixin ],
 
-    propTypes: {
-        ItemRenderer: function(props, propName, componentName) {
+		propTypes: {
+				ItemRenderer: function(props, propName, componentName) {
 // TODO: test if this is a ReactClass
-        },
-        itemClassName: React.PropTypes.string,
-        entries: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-        height: React.PropTypes.number,
-        width: React.PropTypes.number,
-        padding: React.PropTypes.number,
-        wrapperHeight: React.PropTypes.number,
-        lazyCallback: React.PropTypes.func,
-        renderRangeCallback: React.PropTypes.func,
-    },
+				},
+				itemClassName: React.PropTypes.string,
+				entries: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+				height: React.PropTypes.number,
+				width: React.PropTypes.number,
+				padding: React.PropTypes.number,
+				wrapperHeight: React.PropTypes.number,
+				lazyCallback: React.PropTypes.func,
+				renderRangeCallback: React.PropTypes.func,
+				buffer: React.PropTypes.number
+		},
 
-    getDefaultProps: function() {
-        return {
-            padding: 10,
-            entries: [],
-            height: 250,
-            width: 250,
-        };
-    },
+		getDefaultProps: function() {
+				return {
+						padding: 10,
+						entries: [],
+						height: 250,
+						width: 250,
+				};
+		},
 
-    getInitialState: function() {
-        return {
-            initiatedLazyload: false,
-            minHeight: window.innerHeight * 2,
-            minItemIndex: 0,
-            maxItemIndex: 100,
-            itemDimensions: {
-                height: this._itemHeight(),
-                width: this._itemHeight(),
-                gridWidth: 0,
-                itemsPerRow: 2,
-            },
-        };
-    },
+		getInitialState: function() {
+				return {
+						initiatedLazyload: false,
+						minHeight: window.innerHeight * 2,
+						minItemIndex: 0,
+						maxItemIndex: 100,
+						itemDimensions: {
+								height: this._itemHeight(),
+								width: this._itemHeight(),
+								gridWidth: 0,
+								itemsPerRow: 2,
+						},
+				};
+		},
 
-    // METHODS
+		// METHODS
 
-    _wrapperStyle: function() {
-        return {
-            maxHeight: window.innerHeight,
-            overflowY: 'scroll',
-            width: '100%',
-            height: this.props.wrapperHeight,
-            WebkitOverflowScrolling: 'touch',
-        };
-    },
+		_wrapperStyle: function() {
+				return {
+						maxHeight: (window.innerHeight * 2),
+						overflowY: 'scroll',
+						width: '100%',
+						height: this.props.wrapperHeight,
+						WebkitOverflowScrolling: 'touch',
+				};
+		},
 
-    _gridStyle: function() {
-        return {
-            position: "relative",
-            marginTop: this.props.padding,
-            marginLeft: this.props.padding,
-            minHeight: this.state.minHeight,
-        };
-    },
+		_gridStyle: function() {
+				return {
+						position: "relative",
+						marginTop: this.props.padding,
+						marginLeft: this.props.padding,
+						minHeight: this.state.minHeight,
+				};
+		},
 
-    _getGridRect: function() {
-        return this.refs.grid.getDOMNode().getBoundingClientRect();
-    },
+		_getGridRect: function() {
+				return this.refs.grid.getDOMNode().getBoundingClientRect();
+		},
 
-    _getWrapperRect: function() {
-        return this.refs.wrapper.getDOMNode().getBoundingClientRect();
-    },
+		_getWrapperRect: function() {
+				return this.refs.wrapper.getDOMNode().getBoundingClientRect();
+		},
 
-    _visibleIndexes: function() {
-        var itemsPerRow = this._itemsPerRow();
+		_visibleIndexes: function() {
+				var itemsPerRow = this._itemsPerRow();
 
-        // The number of rows that the user has scrolled past
-        var scrolledPast = (this._scrolledPastRows() * itemsPerRow);
-        if (scrolledPast < 0) scrolledPast = 0;
+				// The number of rows that the user has scrolled past
+				var scrolledPast = (this._scrolledPastRows() * itemsPerRow);
+				if (scrolledPast < 0) scrolledPast = 0;
 
-        // If i have scrolled past 20 items, but 60 are visible on screen,
-        // we do not want to change the minimum
-        var min = scrolledPast - itemsPerRow;
-        if (min < 0) min = 0;
+				// If i have scrolled past 20 items, but 60 are visible on screen,
+				// we do not want to change the minimum
+				var min = scrolledPast - itemsPerRow;
+				if (min < 0) min = 0;
 
-        // the maximum should be the number of items scrolled past, plus some
-        // buffer
-        var bufferRows = this._numVisibleRows() + 1;
-        var max = scrolledPast + (itemsPerRow * bufferRows);
-        if (max > this.props.entries.length) max = this.props.entries.length;
+				// the maximum should be the number of items scrolled past, plus some
+				// buffer
+				var bufferRows = this._numVisibleRows() + this.props.buffer;
+				var max = scrolledPast + (itemsPerRow * bufferRows);
+				if (max > this.props.entries.length) max = this.props.entries.length;
 
-        this.setState({
-            minItemIndex: min,
-            maxItemIndex: max,
-        }, function() {
-            this._lazyCallback();
-        });
-    },
+				this.setState({
+						minItemIndex: min,
+						maxItemIndex: max,
+				}, function() {
+						this._lazyCallback();
+				});
+		},
 
-    _updateItemDimensions: function() {
-        this.setState({
-            itemDimensions: {
-                height: this._itemHeight(),
-                width: this._itemHeight(),
-                gridWidth: this._getGridRect().width,
-                itemsPerRow: this._itemsPerRow(),
-            },
-            minHeight: this._totalRows(),
-        });
-    },
+		_updateItemDimensions: function() {
+				this.setState({
+						itemDimensions: {
+								height: this._itemHeight(),
+								width: this._itemHeight(),
+								gridWidth: this._getGridRect().width,
+								itemsPerRow: this._itemsPerRow(),
+						},
+						minHeight: this._totalRows(),
+				});
+		},
 
-    _itemsPerRow: function() {
-        return Math.floor(this._getGridRect().width / this._itemWidth());
-    },
+		_itemsPerRow: function() {
+				return Math.floor(this._getGridRect().width / this._itemWidth());
+		},
 
-    _totalRows: function() {
-        var scrolledPastHeight = (this.props.entries.length / this._itemsPerRow()) * this._itemHeight();
-        if (scrolledPastHeight < 0) return 0;
-        return scrolledPastHeight;
-    },
+		_totalRows: function() {
+				var scrolledPastHeight = (this.props.entries.length / this._itemsPerRow()) * this._itemHeight();
+				if (scrolledPastHeight < 0) return 0;
+				return scrolledPastHeight;
+		},
 
-    _scrolledPastRows: function() {
-        var rect = this._getGridRect();
-        var topScrollOffset = rect.height - rect.bottom;
-        return Math.floor(topScrollOffset / this._itemHeight());
-    },
+		_scrolledPastRows: function() {
+				var rect = this._getGridRect();
+				var topScrollOffset = rect.height - rect.bottom;
+				return Math.floor(topScrollOffset / this._itemHeight());
+		},
 
-    _itemHeight: function() {
-        return this.props.height + (2 * this.props.padding);
-    },
+		_itemHeight: function() {
+				return this.props.height + (2 * this.props.padding);
+		},
 
-    _itemWidth: function() {
-        return this.props.width + (2 * this.props.padding);
-    },
+		_itemWidth: function() {
+				return this.props.width + (2 * this.props.padding);
+		},
 
-    _numVisibleRows: function() {
-        return Math.ceil(this._getWrapperRect().height / this._itemHeight());
-    },
+		_numVisibleRows: function() {
+				return Math.ceil(this._getWrapperRect().height / this._itemHeight());
+		},
 
-    _lazyCallback: function() {
-        if (!this.state.initiatedLazyload && (this.state.maxItemIndex === this.props.entries.length) && this.props.lazyCallback) {
-            this.setState({initiatedLazyload: true });
-            this.props.lazyCallback(this.state.maxItemIndex);
-        }
-    },
+		_lazyCallback: function() {
+				if (!this.state.initiatedLazyload && (this.state.maxItemIndex === this.props.entries.length) && this.props.lazyCallback) {
+						this.setState({initiatedLazyload: true });
+						this.props.lazyCallback(this.state.maxItemIndex);
+				}
+		},
 
-    // LIFECYCLE
+		// LIFECYCLE
 
-    componentWillMount: function() {
-        window.addEventListener('resize', this._resizeListener);
-    },
+		componentWillMount: function() {
+				window.addEventListener('resize', this._resizeListener);
+		},
 
-    componentDidMount: function() {
-        this._updateItemDimensions();
-        this._visibleIndexes();
-    },
+		componentDidMount: function() {
+				this._updateItemDimensions();
+				this._visibleIndexes();
+		},
 
-    componentWillReceiveProps: function(nextProps) {
-        if (nextProps.entries.length > this.props.entries.length) {
-            this.setState({
-                initiatedLazyload: false,
-            });
-        }
-        // Update these all the time because entries may change on the fly.
-        this._updateItemDimensions();
-        this._visibleIndexes();
-    },
+		componentWillReceiveProps: function(nextProps) {
+				if (nextProps.entries.length > this.props.entries.length) {
+						this.setState({
+								initiatedLazyload: false,
+						});
+				}
+				// Update these all the time because entries may change on the fly.
+				this._updateItemDimensions();
+				this._visibleIndexes();
+		},
 
-    componentDidUpdate: function(prevProps, prevState) {
-        if (typeof this.props.renderRangeCallback === 'function') {
-            this.props.renderRangeCallback(this.state.minItemIndex, this.state.maxItemIndex);
-        }
-    },
+		componentDidUpdate: function(prevProps, prevState) {
+				if (typeof this.props.renderRangeCallback === 'function') {
+						this.props.renderRangeCallback(this.state.minItemIndex, this.state.maxItemIndex);
+				}
+		},
 
-    componentWillUnmount: function() {
-        window.removeEventListener('resize', this._resizeListener);
-    },
+		componentWillUnmount: function() {
+				window.removeEventListener('resize', this._resizeListener);
+		},
 
-    // LISTENERS
+		// LISTENERS
 
-    _scrollListener: function(event) {
-        this._visibleIndexes();
-    },
+		_scrollListener: function(event) {
+				this._visibleIndexes();
+		},
 
-    _resizeListener: function(event) {
-        if (!this.props.wrapperHeight) {
-            this.setState({
-                wrapperHeight: window.innerHeight,
-            });
-        }
-        this._updateItemDimensions();
-        this._visibleIndexes();
-    },
+		_resizeListener: function(event) {
+				if (!this.props.wrapperHeight) {
+						this.setState({
+								wrapperHeight: window.innerHeight,
+						});
+				}
+				this._updateItemDimensions();
+				this._visibleIndexes();
+		},
 
-    // RENDER
+		// RENDER
 
-    render: function() {
-        var entries = [];
-        if (this.props.entries.length > 0) {
-            for (var i = this.state.minItemIndex; i <= this.state.maxItemIndex; i++) {
-                var entry = this.props.entries[i];
-                if (entry) {
-                    entries.push(React.createElement(Item, {
-                        ItemRenderer: this.props.ItemRenderer,
-                        itemClassName: this.props.itemClassName,
-                        key: "item-" + i,
-                        index: i,
-                        padding: this.props.padding,
-                        dimensions: this.state.itemDimensions,
-                        data: entry
-                    }));
-                }
-            }
-        }
-	
+		render: function() {
+				var entries = [];
+				if (this.props.entries.length > 0) {
+						for (var i = this.state.minItemIndex; i <= this.state.maxItemIndex; i++) {
+								var entry = this.props.entries[i];
+								if (entry) {
+										entries.push(React.createElement(Item, {
+												ItemRenderer: this.props.ItemRenderer,
+												itemClassName: this.props.itemClassName,
+												key: "item-" + i,
+												index: i,
+												padding: this.props.padding,
+												dimensions: this.state.itemDimensions,
+												data: entry
+										}));
+								}
+						}
+				}
+
 		var grid = React.createElement("div",{
 			ref: "grid",
 			className: "infinite-grid",
@@ -227,7 +228,7 @@ var InfiniteGrid = React.createClass({
 			onScroll: this._scrollListener,
 			style: this._wrapperStyle()
 		},grid);
-    },
+		},
 });
 
 module.exports = InfiniteGrid;

--- a/src/grid.js
+++ b/src/grid.js
@@ -219,7 +219,7 @@ var InfiniteGrid = React.createClass({
 			ref: "grid",
 			className: "infinite-grid",
 			style: this._gridStyle()
-		});
+		},entries);
 
 		return React.createElement("div",{
 			ref:"wrapper",

--- a/src/item.js
+++ b/src/item.js
@@ -3,7 +3,7 @@ var PureRenderMixin = React.addons.PureRenderMixin;
 
 var Item = React.createClass({
 
-    mixins: [ PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	_itemWidth: function() {
 		return this.props.dimensions.gridWidth / this.props.dimensions.itemsPerRow;
@@ -18,23 +18,25 @@ var Item = React.createClass({
 		return Math.floor(this.props.index / this.props.dimensions.itemsPerRow) * this.props.dimensions.height;
 	},
 
-    render: function() {
-        
-    	var style = {
-    		width: this._itemWidth() - this.props.padding,
-    		height: this.props.dimensions.height - this.props.padding,
-    		left: this._itemLeft(),
-    		top: this._itemTop(),
-    		position: "absolute",
-    	};
-        var ItemRenderer = this.props.ItemRenderer;
+	render: function() {
 
-        return(
-            <div ref="item" className={this.props.itemClassName} key={this.props.key+this.props.index} style={style}>
-            	<ItemRenderer {...this.props.data}/>
-            </div>
-        );
-    },
+		var _style = {
+			width: this._itemWidth() - this.props.padding,
+			height: this.props.dimensions.height - this.props.padding,
+			left: this._itemLeft(),
+			top: this._itemTop(),
+			position: "absolute"
+		};
+
+		var ItemRenderer = this.props.ItemRenderer || "div";
+
+		var props = {
+			className: this.props.itemClassName,
+			style: _style
+		};
+
+		return React.createElement("div",props,React.createElement(ItemRenderer,this.props.data));
+	}
 });
 
 module.exports = Item;


### PR DESCRIPTION
Compiling with Browserify is throwing errors because of the JSX syntax in .js files. Those who filed issues weren't using a transformer, but even using Browserify's `reactify` transform only works on project modules, not on packages in the  `node_modules` directory. Unless you run it with the -g flag, but that's really slow every build. This pull request fixes the issue.
