### PR TITLE
Fix grid entries not displaying when num entries < entries per row.

### DIFF
--- a/src/grid.js
+++ b/src/grid.js
@@ -69,7 +69,9 @@ export default class InfiniteGrid extends React.Component {
 	}
 
 	_getGridHeight() {
-		return Math.floor(this.props.entries.length / this.state.itemDimensions.itemsPerRow) * this.state.itemDimensions.height;
+		return (this.props.entries.length < this.state.itemDimensions.itemsPerRow) ?
+			this.state.itemDimensions.height :
+			Math.floor(this.props.entries.length / this.state.itemDimensions.itemsPerRow) * this.state.itemDimensions.height;
 	}
 
 	_getWrapperRect() {


### PR DESCRIPTION
"this.props.entries.length / this.state.itemDimensions.itemsPerRow" yields 0 when there are fewer entries than items per row, causing '_getGridHeight()' to return 0, breaking the grid's style.
