### PR TITLE
Replace deprecated React.PropTypes with prop-types package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ The example below renders a grid with 100,000 items.
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import InfiniteGrid from '../src/grid';
 
 class ExampleItem extends React.Component {
 
   static get propTypes() {
     return {
-      index: React.PropTypes.number
+      index: PropTypes.number
     };
   }
 
@@ -46,15 +47,15 @@ ReactDOM.render(<InfiniteGrid itemClassName={"item"} entries={items} />, documen
 
 ## Required props
 
-- **entries** `React.PropTypes.arrayOf(React.PropTypes.element)` - The only required property is an array of React elements that you want to render.
+- **entries** `PropTypes.arrayOf(PropTypes.element)` - The only required property is an array of React elements that you want to render.
 
 ## Optional props
 
-- **height** `React.PropTypes.number` - The height of the grid item
-- **width** `React.PropTypes.number` - The width of the grid item
-- **padding** `React.PropTypes.number` - The padding around your items
-- **wrapperHeight** `React.PropTypes.number` - The height of the grid.
-- **lazyCallback** `React.PropTypes.func` - A function that takes no arguments which is called when a user reaches the end of the grid. Useful if you want to lazy load your data.
+- **height** `PropTypes.number` - The height of the grid item
+- **width** `PropTypes.number` - The width of the grid item
+- **padding** `PropTypes.number` - The padding around your items
+- **wrapperHeight** `PropTypes.number` - The height of the grid.
+- **lazyCallback** `PropTypes.func` - A function that takes no arguments which is called when a user reaches the end of the grid. Useful if you want to lazy load your data.
 
 # Demo
 

--- a/dist/grid.js
+++ b/dist/grid.js
@@ -1,14 +1,18 @@
 'use strict';
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
 Object.defineProperty(exports, "__esModule", {
 	value: true
 });
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _lodash = require('lodash');
 
@@ -24,7 +28,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var InfiniteGrid = (function (_React$Component) {
+var InfiniteGrid = function (_React$Component) {
 	_inherits(InfiniteGrid, _React$Component);
 
 	_createClass(InfiniteGrid, [{
@@ -47,15 +51,15 @@ var InfiniteGrid = (function (_React$Component) {
 		key: 'propTypes',
 		get: function get() {
 			return {
-				itemClassName: _react2.default.PropTypes.string,
-				entries: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.object).isRequired,
-				height: _react2.default.PropTypes.number,
-				width: _react2.default.PropTypes.number,
-				padding: _react2.default.PropTypes.number,
-				wrapperHeight: _react2.default.PropTypes.number,
-				lazyCallback: _react2.default.PropTypes.func,
-				renderRangeCallback: _react2.default.PropTypes.func,
-				buffer: _react2.default.PropTypes.number
+				itemClassName: _propTypes2.default.string,
+				entries: _propTypes2.default.arrayOf(_propTypes2.default.object).isRequired,
+				height: _propTypes2.default.number,
+				width: _propTypes2.default.number,
+				padding: _propTypes2.default.number,
+				wrapperHeight: _propTypes2.default.number,
+				lazyCallback: _propTypes2.default.func,
+				renderRangeCallback: _propTypes2.default.func,
+				buffer: _propTypes2.default.number
 			};
 		}
 	}]);
@@ -63,15 +67,15 @@ var InfiniteGrid = (function (_React$Component) {
 	function InfiniteGrid(props) {
 		_classCallCheck(this, InfiniteGrid);
 
-		var _this2 = _possibleConstructorReturn(this, Object.getPrototypeOf(InfiniteGrid).call(this, props));
+		var _this = _possibleConstructorReturn(this, (InfiniteGrid.__proto__ || Object.getPrototypeOf(InfiniteGrid)).call(this, props));
 
-		_this2.state = _this2.initialState();
+		_this.state = _this.initialState();
 		// bind the functions
-		_this2._scrollListener = _this2._scrollListener.bind(_this2);
-		_this2._updateItemDimensions = _this2._updateItemDimensions.bind(_this2);
-		_this2._resizeListener = _this2._resizeListener.bind(_this2);
-		_this2._visibleIndexes = _this2._visibleIndexes.bind(_this2);
-		return _this2;
+		_this._scrollListener = _this._scrollListener.bind(_this);
+		_this._updateItemDimensions = _this._updateItemDimensions.bind(_this);
+		_this._resizeListener = _this._resizeListener.bind(_this);
+		_this._visibleIndexes = _this._visibleIndexes.bind(_this);
+		return _this;
 	}
 
 	// METHODS
@@ -105,7 +109,7 @@ var InfiniteGrid = (function (_React$Component) {
 	}, {
 		key: '_getGridHeight',
 		value: function _getGridHeight() {
-			return Math.floor(this.props.entries.length / this.state.itemDimensions.itemsPerRow) * this.state.itemDimensions.height;
+			return this.props.entries.length < this.state.itemDimensions.itemsPerRow ? this.state.itemDimensions.height : Math.floor(this.props.entries.length / this.state.itemDimensions.itemsPerRow) * this.state.itemDimensions.height;
 		}
 	}, {
 		key: '_getWrapperRect',
@@ -243,11 +247,11 @@ var InfiniteGrid = (function (_React$Component) {
 	}, {
 		key: '_scrollListener',
 		value: function _scrollListener(event) {
-			var _this = this;
+			var _this2 = this;
 
 			clearTimeout(this.scrollOffset);
 			this.scrollOffset = setTimeout(function () {
-				_this._visibleIndexes();
+				_this2._visibleIndexes();
 			}, 10);
 		}
 	}, {
@@ -301,7 +305,7 @@ var InfiniteGrid = (function (_React$Component) {
 	}]);
 
 	return InfiniteGrid;
-})(_react2.default.Component);
+}(_react2.default.Component);
 
 exports.default = InfiniteGrid;
 ;

--- a/dist/item.js
+++ b/dist/item.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
 Object.defineProperty(exports, "__esModule", {
 	value: true
 });
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
@@ -20,13 +20,13 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var Item = (function (_React$Component) {
+var Item = function (_React$Component) {
 	_inherits(Item, _React$Component);
 
 	function Item(props) {
 		_classCallCheck(this, Item);
 
-		return _possibleConstructorReturn(this, Object.getPrototypeOf(Item).call(this, props));
+		return _possibleConstructorReturn(this, (Item.__proto__ || Object.getPrototypeOf(Item)).call(this, props));
 	}
 
 	_createClass(Item, [{
@@ -85,6 +85,6 @@ var Item = (function (_React$Component) {
 	}]);
 
 	return Item;
-})(_react2.default.Component);
+}(_react2.default.Component);
 
 exports.default = Item;

--- a/example/main.js
+++ b/example/main.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import InfiniteGrid from '../src/grid';
 
 class ExampleItem extends React.Component {
 
   static get propTypes() {
     return {
-      index: React.PropTypes.number
+      index: PropTypes.number
     };
   }
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^3.10.1",
-    "react": "^0.14.2",
-    "react-dom": "^0.14.2"
+    "prop-types": "^15.6.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "devDependencies": {
     "babel": "^6.1.18",

--- a/src/grid.js
+++ b/src/grid.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {isEqual} from 'lodash';
 import Item from './item';
 
@@ -6,15 +7,15 @@ export default class InfiniteGrid extends React.Component {
 
 	static get propTypes() {
 		return {
-			itemClassName: React.PropTypes.string,
-			entries: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-			height: React.PropTypes.number,
-			width: React.PropTypes.number,
-			padding: React.PropTypes.number,
-			wrapperHeight: React.PropTypes.number,
-			lazyCallback: React.PropTypes.func,
-			renderRangeCallback: React.PropTypes.func,
-			buffer: React.PropTypes.number
+			itemClassName: PropTypes.string,
+			entries: PropTypes.arrayOf(PropTypes.object).isRequired,
+			height: PropTypes.number,
+			width: PropTypes.number,
+			padding: PropTypes.number,
+			wrapperHeight: PropTypes.number,
+			lazyCallback: PropTypes.func,
+			renderRangeCallback: PropTypes.func,
+			buffer: PropTypes.number
 		}
 	}
 


### PR DESCRIPTION
React.PropTypes has been deprecated for a while, and has been removed entirely from React 16.0. This PR replaces React.PropTypes with PropTypes from the designated _prop-types_ package.

I've separated the build (`dist/`) into a separate commit so as to make it easier for maintainers to see what has actually changed. I can merge these two together before merge if so desired.